### PR TITLE
🚨 Updated snakecase-keys due to alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "notarize-node-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notarize-node-client",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=10.0.0",
         "camelcase-keys": "^6.2.2",
         "node-fetch": "^2.6.1",
-        "snakecase-keys": "^4.0.2"
+        "snakecase-keys": "^5.5.0"
       },
       "devDependencies": {
         "@types/delay": "^3.1.0",
@@ -1769,16 +1769,27 @@
       }
     },
     "node_modules/snakecase-keys": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-4.0.2.tgz",
-      "integrity": "sha512-ZFCo3zZtNN43cy2j4fQDHPxS557Uuzn887FBmDdaSB41D8l/MayuvaSrIlCXGFhZ8sXwrHiNaZiIPpKzi88gog==",
-      "deprecated": "This version contains a breaking change for users depending on unspecified behaviors with repeated capital letters. See https://github.com/bendrucker/snakecase-keys/issues/47. Please upgrade to the identical 5.0.0 release instead.",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.5.0.tgz",
+      "integrity": "sha512-r3kRtnoPu3FxGJ3fny6PKNnU3pteb29o6qAa0ugzhSseKNWRkw1dw8nIjXMyyKaU9vQxxVIE62Mb3bKbdrgpiw==",
       "dependencies": {
         "map-obj": "^4.1.0",
-        "snake-case": "^3.0.4"
+        "snake-case": "^3.0.4",
+        "type-fest": "^3.12.0"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/snakecase-keys/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notarize-node-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Node.js Client for Notarize.com Business API",
   "keywords": [
     "notarize.com",
@@ -48,7 +48,7 @@
     "@types/node": ">=10.0.0",
     "camelcase-keys": "^6.2.2",
     "node-fetch": "^2.6.1",
-    "snakecase-keys": "^4.0.2"
+    "snakecase-keys": "^5.5.0"
   },
   "scripts": {
     "ts": "ts-node -r dotenv/config",

--- a/tests/update-document.ts
+++ b/tests/update-document.ts
@@ -50,7 +50,7 @@ import { Notarize } from '../src/index'
     } else {
       console.log('Error! I was unable to pull the original document:')
       console.log(chk)
-     }
+    }
   }
 
   if (one.success) {


### PR DESCRIPTION
There was an alert on the use of snakecase-keys 4.x, so knowing there's no damage to our use of the 5.x series, this is just an upgrade to make sure we don't have the warnings again. Simple. Clean.